### PR TITLE
Add support for undocumented server feature of managing extensions

### DIFF
--- a/tsp-cli-client
+++ b/tsp-cli-client
@@ -68,6 +68,9 @@ if __name__=="__main__":
     parser.add_argument("--list-outputs", dest="list_outputs", help="Gets details on the given trace", metavar="UUID")
     parser.add_argument("--get-tree", dest="get_tree", help="Gets the tree of an output", metavar="OUTPUT_ID")
     parser.add_argument("--uuid", dest="uuid", help="The UUID of a trace")
+    parser.add_argument("--list-extensions", dest="extensions", action='store_true', help="Get the extensions loaded")
+    parser.add_argument("--load-extension", dest="load_extensions", help="Load an extension", metavar="EXTENSION_PATH")
+    parser.add_argument("--delete-extension", dest="delete_extensions", help="Delete an extension", metavar="EXTENSION_NAME")
 
     options = parser.parse_args()
 
@@ -156,6 +159,35 @@ if __name__=="__main__":
                     sys.exit(1)
             else:
                 print("Trace UUID is missing")
+                sys.exit(1)
+        
+        if (options.extensions):
+            response = tsp_client.fetch_extensions()
+            if response.status_code == 200:
+                extension_set = response.model
+
+                if not extension_set:
+                    print('No extensions loaded')
+
+                for e in extension_set.extension_set:
+                    print('  {0}'.format(e.extension))
+
+                sys.exit(0)
+            else:
+                sys.exit(1)
+
+        if (options.load_extensions):
+            response = tsp_client.post_extensions(options.load_extensions)
+            if response.status_code == 200:
+                sys.exit(0)
+            else:
+                sys.exit(1)
+
+        if (options.delete_extensions):
+            response = tsp_client.delete_extensions(options.delete_extensions)
+            if response.status_code == 200:
+                sys.exit(0)
+            else:
                 sys.exit(1)
     except ConnectionError as e:
         print('Unexpected error: {0}'.format(e))

--- a/tsp/extension.py
+++ b/tsp/extension.py
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2020 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+class Extension(object):
+    '''
+    Class to handle extensions available on the remote node
+    '''
+
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+        self.extension = params

--- a/tsp/extension_set.py
+++ b/tsp/extension_set.py
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2020 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from tsp.extension import Extension
+
+
+class ExtensionSet(object):
+    '''
+    Class to handle extensions available on the remote node
+    '''
+
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+        self.extension_set = []
+        for obj in params:
+            self.extension_set.append(Extension(obj))

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -27,8 +27,10 @@ import json
 from tsp.tsp_client_response import TspClientResponse
 from tsp.output_descriptor_set import OutputDescriptorSet
 from tsp.response import GenericResponse, ModelType
+from tsp.extension_set import ExtensionSet
 
 headers = {'content-type': 'application/json', 'Accept': 'application/json'}
+headers_form = {'content-type': 'application/x-www-form-urlencoded', 'Accept': 'application/json'}
 
 PARAMETERS_KEY = 'parameters'
 REQUESTED_TIME_KEY = 'requested_times'
@@ -165,4 +167,47 @@ class TspClient(object):
             return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')), ModelType.TIME_GRAPH_TREE), response.status_code, response.text)
         else:
             print("failed to get tree: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    '''
+    Fetch Extensions (loaded files)
+     '''
+    def fetch_extensions(self):
+        api_url = '{0}xml'.format(self.base_url)
+
+        response = requests.get(api_url, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(ExtensionSet(json.loads(response.content.decode('utf-8'))), response.status_code, response.text)
+        else:
+            print("failed to get extensions: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    '''
+    Load an extension
+     '''
+    def post_extensions(self, mypath):
+        api_url = '{0}xml'.format(self.base_url)
+
+        payload = dict(path=mypath)
+        response = requests.post(api_url, data=payload, headers=headers_form)
+
+        if response.status_code == 200:
+            return TspClientResponse("Loaded", response.status_code, response.text)
+        else:
+            print("post extension failed: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    '''
+    Delete an extension
+     '''
+    def delete_extensions(self, name):
+        api_url = '{0}xml/{1}'.format(self.base_url, name)
+
+        response = requests.delete(api_url, headers=headers_form)
+
+        if response.status_code == 200:
+            return TspClientResponse("Deleted", response.status_code, response.text)
+        else:
+            print("post extension failed: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)


### PR DESCRIPTION
Right now, XML analysis extensions of Trace Compass are supported. This
features is not part of the TSP at the moment, but it's an example
how extensions can be implemented in the future.

Signed-off-by: Bernd Hufmann <Bernd.Hufmann@ericsson.com>