### PR TITLE
Add local standard autopep8/pylint to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 argcomplete
+autopep8
 datetime
 pandas
+pylint
 pytest
 pytest-cov
 requests


### PR DESCRIPTION
Before this change, one had to manually install these libraries. Now,
following the existing README setup instructions will install both in
the local virtual environment.

This git repository already has these set in ./.vscode/settings.json.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>